### PR TITLE
feat: automate deployment to chongzixin.github.io parent report

### DIFF
--- a/.github/workflows/send-submodule-updates-to-githubio.yml
+++ b/.github/workflows/send-submodule-updates-to-githubio.yml
@@ -3,7 +3,7 @@ name: Send submodule updates to parent repo
 on:
   push:
     branches: 
-      - actions-push-deploy
+      - main
 
 jobs:
   update:

--- a/.github/workflows/send-submodule-updates-to-githubio.yml
+++ b/.github/workflows/send-submodule-updates-to-githubio.yml
@@ -1,0 +1,29 @@
+name: Send submodule updates to parent repo
+
+on:
+  push:
+    branches: 
+      - actions-push-deploy
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          repository: chongzixin/chongzixin.github.io
+          submodules: 'true'
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_SUBMODULE_UPDATES }}
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ npm install
 npm run start
 ```
 
+# Other Notes
+- This repo is a submodule on `chongzixin.github.io`. GitHub Actions have been setup to automatically trigger a submodule update on the parent repository whenever there is a push to the main branch.
+
 
 # Other Solutions Considered
 - **Excel** - the UIUX for training navigation keys is fundamentally a grid view. Hence Excel came to mind as the "mother of spreadsheets". However, we can't constrain the arrow key navigation to 2 rows (as in the YouTube Kids App), so it is easy for the user to "lose" where we want them to try if they press and hold the down arrow and reach Row 2000 when we want them to navigate within Rows 1 and 5.


### PR DESCRIPTION
The parent repo chongzixin.github.io uses this repo as a submodule. This PR triggers the parent repo to do a submodule update whenever a push is detected on this repo's `main` branch, so that changes get automatically deployed to https://chongzixin.github.io for use.